### PR TITLE
Updated Anonymizable trait

### DIFF
--- a/src/Anonymizable.php
+++ b/src/Anonymizable.php
@@ -47,7 +47,9 @@ trait Anonymizable
                         $collection = [$collection];
                     }
                     foreach ($collection as $item) {
-                        $item->anonymize($modelChecker);
+                        if (isset($item)) {
+                            $item->anonymize($modelChecker);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Added check to make sure item value is not null before calling anonymize. This will prevent null fields in relations from causing exceptions. 

Fixes exception Call to a member function anonymize() on null