### PR TITLE
Updates to toDecryptedArray()

### DIFF
--- a/src/EncryptsAttributes.php
+++ b/src/EncryptsAttributes.php
@@ -47,9 +47,12 @@ trait EncryptsAttributes
      */
     public function decryptToArray()
     {
-        $model = [];
-        foreach ($this->attributes as $attributeKey => $attributeValue) {
-            $model[$attributeKey] = $this->$attributeKey;
+        $model = parent::toArray();
+
+        foreach ($model as $key => $value) {
+            if(in_array($key, $this->encrypted) && ! is_null($value)) {
+                $model[$key] = decrypt($model[$key]);
+            }
         }
 
         return $model;
@@ -61,11 +64,7 @@ trait EncryptsAttributes
      */
     public function decryptToCollection()
     {
-        $model = collect();
-        foreach ($this->attributes as $attributeKey => $attributeValue) {
-            $model->$attributeKey = $this->$attributeKey;
-        }
-
-        return $model;
+        return collect($this->decryptToArray());
     }
 }
+


### PR DESCRIPTION
Previous implementation of this function did not account for certain casts.
The new implementation uses the parents toArray function and replaces the encrypted attributes with its decrypted counterpart.